### PR TITLE
ARCH-1205 - No default commitish

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This action also has the option of deleting the release if it already exists.  I
 | `github-token`            | true                             | A token with permission to create and delete releases.  Generally secrets.GITHUB_TOKEN.                                                    |
 | `tag-name`                | true                             | The name of the tag.                                                                                                                       |
 | `release-name`            | false                            | The name of the release. Defaults to the tag name if not provided.                                                                         |
-| `commitish`               | true                             | Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA.                          |
+| `commitish`               | true                             | Specifies the commitish value that identifies the commit to tag. Can be any branch or commit SHA.                                          |
 | `body`                    | false                            | Text describing the contents of the release.                                                                                               |
 | `body-path`               | false                            | Path to file with information about the release.                                                                                           |
 | `draft`                   | false                            | Flag indicating whether to create a draft (unpublished) release or a published one.<br/>Accepted Values: `true\|false`.  Default: `false`. |

--- a/README.md
+++ b/README.md
@@ -18,20 +18,20 @@ This action also has the option of deleting the release if it already exists.  I
 - [License](#license)
 
 ## Inputs
-| Parameter                 | Is Required                      | Description                                                                                                                                                                   |
-| ------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `github-token`            | true                             | A token with permission to create and delete releases.  Generally secrets.GITHUB_TOKEN.                                                                                       |
-| `tag-name`                | true                             | The name of the tag.                                                                                                                                                          |
-| `release-name`            | false                            | The name of the release. Defaults to the tag name if not provided.                                                                                                            |
-| `commitish`               | false                            | Any branch or commit SHA the Git tag is created from. <br/><br/>Defaults: <br/>• `pull_request` triggers: `context.pull_request.head.sha`<br/>• Other triggers: `context.sha` |
-| `body`                    | false                            | Text describing the contents of the release.                                                                                                                                  |
-| `body-path`               | false                            | Path to file with information about the release.                                                                                                                              |
-| `draft`                   | false                            | Flag indicating whether to create a draft (unpublished) release or a published one.<br/>Accepted Values: `true\|false`.  Default: `false`.                                    |
-| `prerelease`              | false                            | Flag indicating whether this release is a pre-release or a full release.<br/>Accepted Values: `true\|false`.  Default: `false`.                                               |
-| `delete-existing-release` | false                            | Flag indicating whether to delete then re-create a release if it already exists.<br/>Accepted Values: `true\|false`.  Default: `false`.                                       |
-| `asset-path`              | Required when uploading an asset | The path to the asset you want to upload.  Required when uploading an asset.                                                                                                  |
-| `asset-name`              | Required when uploading an asset | The name of the asset you want to upload.   Required when uploading an asset.                                                                                                 |
-| `asset-content-type`      | Required when uploading an asset | The content-type of the asset you want to upload. See the [supported Media Types].  Required when uploading an asset.                                                         |
+| Parameter                 | Is Required                      | Description                                                                                                                                |
+| ------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `github-token`            | true                             | A token with permission to create and delete releases.  Generally secrets.GITHUB_TOKEN.                                                    |
+| `tag-name`                | true                             | The name of the tag.                                                                                                                       |
+| `release-name`            | false                            | The name of the release. Defaults to the tag name if not provided.                                                                         |
+| `commitish`               | true                             | Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA.                          |
+| `body`                    | false                            | Text describing the contents of the release.                                                                                               |
+| `body-path`               | false                            | Path to file with information about the release.                                                                                           |
+| `draft`                   | false                            | Flag indicating whether to create a draft (unpublished) release or a published one.<br/>Accepted Values: `true\|false`.  Default: `false`. |
+| `prerelease`              | false                            | Flag indicating whether this release is a pre-release or a full release.<br/>Accepted Values: `true\|false`.  Default: `false`.            |
+| `delete-existing-release` | false                            | Flag indicating whether to delete then re-create a release if it already exists.<br/>Accepted Values: `true\|false`.  Default: `false`.    |
+| `asset-path`              | Required when uploading an asset | The path to the asset you want to upload.  Required when uploading an asset.                                                               |
+| `asset-name`              | Required when uploading an asset | The name of the asset you want to upload.   Required when uploading an asset.                                                              |
+| `asset-content-type`      | Required when uploading an asset | The content-type of the asset you want to upload. See the [supported Media Types].  Required when uploading an asset.                      |
 
 ## Outputs
 | Output                       | Description                                                       |
@@ -46,19 +46,35 @@ This action also has the option of deleting the release if it already exists.  I
 ```yml
 on: 
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, closed]
 
 env:
   PROJECT_ROOT: './src/MyProj'
   DEPLOY_ZIP: 'published_app.zip'
 
 jobs:
-  create-prebuilt-artifacts-release:
+  create-prebuilt-artifacts-and-release:
     runs-on: ubuntu-latest
     steps:
+      - name: Determine commitish to build and tag
+        uses: actions/github-script@v6
+        with: 
+          script: |
+            const targetRef = '${{ github.base_ref }}';
+            const sourceRef = '${{ github.head_ref }}';
+            const mergeRef = '${{ github.ref }}';
+            
+            const prMergedToMain = '${{ github.event.pull_request.merged }}' === 'true' && targetRef === 'main';
+            const isPreRelease = !prMergedToMain
+            
+            const refToBuildAndTag = prMergedToMain ? mergeRef : sourceRef;
+            core.exportVariable('REF_TO_BUILD', refToBuildAndTag);
+            core.exportVariable('IS_PRERELEASE', isPreRelease);
+            
       - uses: actions/checkout@v2
         with: 
           fetch-depth: 0
+          ref: ${{ env.REF_TO_BUILD }}
 
       - name: Calculate next version
         id: version
@@ -73,21 +89,20 @@ jobs:
           dotnet publish -c Release -o ./published_app 
           (cd published_app && zip -r ../${{env.DEPLOY_ZIP}} .)
 
-      - name: Create Pre-release
+      - name: Create Release
         id: create_release
-        uses: im-open/create-release@v2.0.4
+        uses: im-open/create-release@v3.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           tag-name: ${{ steps.version.outputs.VERSION }}
-          prerelease: true
+          commitish: ${{ env.REF_TO_BUILD }}
+          prerelease: ${{ env.IS_PRERELEASE }}
           asset-path: ${{ env.PROJECT_ROOT }}/${{ env.DEPLOY_ZIP }}
           asset-name: ${{ env.DEPLOY_ZIP }}
           asset-content-type: application/zip
-          # The release might already exist if you hit 're-run jobs' on a workflow run that already
-          # completed once. Creating a release when one already exists will fail, add the tag to delete it.
+          # The release might already exist if you hit 're-run jobs' on a workflow run that already completed
+          # once. Creating a release when one already exists will fail, add the arg here to just delete it.
           delete-existing-release: true
-  run-tests    
-    ...
 ```
 
 ## Contributing

--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,8 @@ inputs:
     description: 'The name of the release. Defaults to the tag name if not provided.'
     required: false
   commitish:
-    description: 'Any branch or commit SHA the Git tag is created from. Default: SHA of current commit.'
-    required: false
+    description: 'Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA.'
+    required: true
   body:
     description: 'Text describing the contents of the release.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: 'The name of the release. Defaults to the tag name if not provided.'
     required: false
   commitish:
-    description: 'Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA.'
+    description: 'Specifies the commitish value that identifies the commit to tag. Can be any branch or commit SHA.'
     required: true
   body:
     description: 'Text describing the contents of the release.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -30690,27 +30690,13 @@ var bodyPath = core.getInput('body-path');
 var draft = core.getInput('draft') === 'true';
 var prerelease = core.getInput('prerelease') === 'true';
 var shouldDeleteExistingRelease = core.getInput('delete-existing-release') === 'true';
+var commitish = core.getInput('commitish');
 var assetPath = core.getInput('asset-path');
 var assetName = core.getInput('asset-name');
 var assetContentType = core.getInput('asset-content-type');
 var tag = tagInput.replace('refs/tags/', '');
 var releaseName = releaseNameInput.replace('refs/tags/', '');
 var github = new GitHub(token);
-var commitish = core.getInput('commitish');
-if (!commitish) {
-  if (context.eventName == 'pull_request') {
-    core.info(`Current github context.sha: ${context.sha}`);
-    core.info(`Current github context.PR.head.sha: ${context.payload.pull_request.head.sha}`);
-    core.info(`The commitish arg was empty for the pull_request, using PR's head sha: ${context.payload.pull_request.head.sha}`);
-    commitish = context.payload.pull_request.head.sha;
-  } else {
-    core.info(`The commitish arg was empty, using context.sha: ${context.sha}`);
-    commitish = context.sha;
-  }
-} else {
-  commitish = commitish.replace('refs/heads/', '').replace('refs/tags/', '');
-  core.info(`The commitish arg was provided, using ${commitish}`);
-}
 var release_id;
 var release_html_url;
 var asset_upload_url;
@@ -30718,15 +30704,6 @@ var asset_browser_download_url;
 var hasAssetToUpload = true;
 function isEmpty(valueToTest) {
   return !valueToTest || valueToTest.trim().length === 0;
-}
-if (isEmpty(assetPath) && isEmpty(assetName) && isEmpty(assetContentType)) {
-  hasAssetToUpload = false;
-} else if (isEmpty(assetPath) || isEmpty(assetName) || isEmpty(assetContentType)) {
-  core.setFailed(`One or more arguments required to upload an asset were not provided:
-	asset-name:'${assetName}'
-	asset-path:'${assetPath}'
-	asset-content-type:'${assetContentType}'`);
-  return;
 }
 async function deleteExistingRelease() {
   core.info('Checking if the release exists...');
@@ -30815,6 +30792,15 @@ async function uploadAsset(uploadUrl) {
   }
 }
 async function run() {
+  if (isEmpty(assetPath) && isEmpty(assetName) && isEmpty(assetContentType)) {
+    hasAssetToUpload = false;
+  } else if (isEmpty(assetPath) || isEmpty(assetName) || isEmpty(assetContentType)) {
+    core.setFailed(`One or more arguments required to upload an asset were not provided:
+	asset-name:'${assetName}'
+	asset-path:'${assetPath}'
+	asset-content-type:'${assetContentType}'`);
+    return;
+  }
   if (shouldDeleteExistingRelease) {
     await deleteExistingRelease();
   }


### PR DESCRIPTION
# Summary of PR changes

- Updating the action so we don't provide a default commitish value.  It's led to confusion and things not being tagged appropriately depending on how items were merged so we'll leave it up to the user to decide what should be tagged.

## PR Requirements
- [x] For JavaScript actions, the action has been recompiled.  
  - See the *Recompiling* section of the repository's README.md for more details.
  - This does not apply to Composite Run Steps actions unless a package.json is present and contains a build script.
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
